### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ allprojects {
 apply from: "$rootDir/gradle/config/scripts/idea.gradle"
 
 flyway {
-    url = 'jdbc:mysql://localhost:3306/zero_test?useUnicode=true&characterEncoding=utf-8&useSSL=false&allowPublicKeyRetrieval=true'
+    url = 'jdbc:mysql://localhost:3306/zero_test?useUnicode=true&characterEncoding=utf-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=GMT'
     user = 'zero'
     password = 'geektime'
     locations = ["filesystem:$rootDir/gradle/config/migration"]


### PR DESCRIPTION
中文版windows10使用MySQL 8.0需要在url后面添加serverTimezone字段保证处于同一时区，否则出现异常：The server time zone value '???ú±ê×??±??' is unrecognized or represents more；英文版windows10未出现该问题